### PR TITLE
Correct naming convention to match standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Python Orbital Ephemeris Message tools
-Python tools for working with Orbital Ephemeris Messages (OEMs).
+# Python Orbit Ephemeris Message tools
+Python tools for working with Orbit Ephemeris Messages (OEMs).
 
 
 ## Development Status
@@ -16,13 +16,13 @@ pip install oem
 ```
 
 ## Usage
-The `OrbitalEphemerisMessage` class is the primary interface for OEM Files.
+The `OrbitEphemerisMessage` class is the primary interface for OEM Files.
 ```python
-from oem import OrbitalEphemerisMessage
+from oem import OrbitEphemerisMessage
 
-ephemeris = OrbitalEphemerisMessage.from_ascii_oem(file_path)
+ephemeris = OrbitEphemerisMessage.from_ascii_oem(file_path)
 ```
-Each OEM is made up of one or more segments of state and optional covariance data. The `OrbitalEphemerisMessage` class provides iterables for both.
+Each OEM is made up of one or more segments of state and optional covariance data. The `OrbitEphemerisMessage` class provides iterables for both.
 ```python
 for segment in ephemeris:
     for state in segment:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,8 @@
-Orbital Ephemeris Message
+Orbit Ephemeris Message
 ================================
 
 The primary interface between the `oem` package and OEM files is the
-`OrbitalEphemerisMessage` class. In addition, the package provides objects to
+`OrbitEphemerisMessage` class. In addition, the package provides objects to
 represent each component of an OEM ephemeris.
 
 .. toctree::

--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -1,6 +1,6 @@
 .. _interface:
 
-OrbitalEphemerisMessage
+OrbitEphemerisMessage
 =================================
 
 .. seealso::
@@ -10,7 +10,7 @@ OrbitalEphemerisMessage
    Module :ref:`types`
 
 
-.. automodule:: oem.OrbitalEphemerisMessage
+.. automodule:: oem.OrbitEphemerisMessage
     :members:
     :undoc-members:
     :show-inheritance:

--- a/oem/__init__.py
+++ b/oem/__init__.py
@@ -1,6 +1,6 @@
 
 CURRENT_VERSION = "2.0"
 
-from .interface import OrbitalEphemerisMessage  # noqa
+from .interface import OrbitEphemerisMessage  # noqa
 
-__all__ = ['OrbitalEphemerisMessage']
+__all__ = ['OrbitEphemerisMessage']

--- a/oem/interface.py
+++ b/oem/interface.py
@@ -54,8 +54,8 @@ class ConstrainOemStates(Constraint):
         )
 
 
-class OrbitalEphemerisMessage(object):
-    """Python representation of an Orbital Ephemeris Message.
+class OrbitEphemerisMessage(object):
+    """Python representation of an Orbit Ephemeris Message.
 
     This class provides the primary interface between the OEM module and an
     OEM file.
@@ -64,9 +64,9 @@ class OrbitalEphemerisMessage(object):
         header (HeaderSection): Object containing the OEM header section.
 
     Examples:
-        The `OrbitalEphemerisMessage` class can load directly from a file:
+        The `OrbitEphemerisMessage` class can load directly from a file:
 
-        >>> ephemeris = OrbitalEphemerisMessage.from_ascii_oem(file_path)
+        >>> ephemeris = OrbitEphemerisMessage.from_ascii_oem(file_path)
 
         An OEM is made up of one or more data segments available through an
         iterator:
@@ -95,7 +95,7 @@ class OrbitalEphemerisMessage(object):
     )
 
     def __init__(self, header, segments):
-        '''Create an Orbital Ephemeris Message.
+        '''Create an Orbit Ephemeris Message.
 
         Args:
             header (HeaderSection): Object containing the OEM header section.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     version=version,
     author="Brad Sease",
     author_email="bradsease@gmail.com",
-    description="Python Orbital Ephemeris Message (OEM) tools",
+    description="Python Orbit Ephemeris Message (OEM) tools",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/bradsease/oem",

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -3,7 +3,7 @@
 import pytest
 import tempfile
 from pathlib import Path
-from oem import OrbitalEphemerisMessage
+from oem import OrbitEphemerisMessage
 
 
 THIS_DIR = Path(__file__).parent
@@ -24,7 +24,7 @@ def test_valid_v1_kvn_samples(file_path):
 
     This test requires external data.
     """
-    oem = OrbitalEphemerisMessage.from_ascii_oem(file_path)
+    oem = OrbitEphemerisMessage.from_ascii_oem(file_path)
 
     for segment in oem:
         for state in segment.states:
@@ -35,7 +35,7 @@ def test_valid_v1_kvn_samples(file_path):
     with tempfile.TemporaryDirectory() as tmp_dir:
         written_oem_path = Path(tmp_dir) / "written.oem"
         oem.save_as(written_oem_path)
-        written_oem = OrbitalEphemerisMessage.from_ascii_oem(written_oem_path)
+        written_oem = OrbitEphemerisMessage.from_ascii_oem(written_oem_path)
         assert written_oem.version == oem.version
 
 
@@ -49,7 +49,7 @@ def test_invalid_v1_kvn_samples(file_path):
     This test requires external data.
     """
     with pytest.raises(Exception):
-        OrbitalEphemerisMessage.from_ascii_oem(file_path)
+        OrbitEphemerisMessage.from_ascii_oem(file_path)
 
 
 @pytest.mark.parametrize("file_path", _get_test_files("v2_0", "KVN", "valid"))
@@ -58,7 +58,7 @@ def test_valid_v2_kvn_samples(file_path):
 
     This test requires external data.
     """
-    oem = OrbitalEphemerisMessage.from_ascii_oem(file_path)
+    oem = OrbitEphemerisMessage.from_ascii_oem(file_path)
     assert oem.version == "2.0"
 
     for segment in oem:
@@ -76,7 +76,7 @@ def test_valid_v2_kvn_samples(file_path):
     with tempfile.TemporaryDirectory() as tmp_dir:
         written_oem_path = Path(tmp_dir) / "written.oem"
         oem.save_as(written_oem_path)
-        written_oem = OrbitalEphemerisMessage.from_ascii_oem(written_oem_path)
+        written_oem = OrbitEphemerisMessage.from_ascii_oem(written_oem_path)
         assert written_oem.version == oem.version
 
 
@@ -90,7 +90,7 @@ def test_invalid_v2_kvn_samples(file_path):
     This test requires external data.
     """
     with pytest.raises(Exception):
-        OrbitalEphemerisMessage.from_ascii_oem(file_path)
+        OrbitEphemerisMessage.from_ascii_oem(file_path)
 
 
 @pytest.mark.parametrize(
@@ -103,7 +103,7 @@ def test_invalid_v1_xml_samples(file_path):
     This test requires external data.
     """
     with pytest.raises(Exception):
-        OrbitalEphemerisMessage.from_xml_oem(file_path)
+        OrbitEphemerisMessage.from_xml_oem(file_path)
 
 
 @pytest.mark.parametrize("file_path", _get_test_files("v2_0", "XML", "valid"))
@@ -112,7 +112,7 @@ def test_valid_v2_xml_samples(file_path):
 
     This test requires external data.
     """
-    oem = OrbitalEphemerisMessage.from_xml_oem(file_path)
+    oem = OrbitEphemerisMessage.from_xml_oem(file_path)
     assert oem.version == "2.0"
 
     for segment in oem:


### PR DESCRIPTION
Corrected code and documentation to refer to `OrbitEphemerisMessage`, not `OrbitalEphemerisMessage`.