### PR TITLE
Make from_string methods private

### DIFF
--- a/oem/components/covariance.py
+++ b/oem/components/covariance.py
@@ -41,7 +41,7 @@ class CovarianceSection(object):
         return iter(self.covariances)
 
     @classmethod
-    def from_string(cls, segment, version):
+    def _from_string(cls, segment, version):
         """Create CovarianceSection from OEM-formatted string.
 
         Args:
@@ -56,7 +56,7 @@ class CovarianceSection(object):
             re.MULTILINE
         )
         covariances = [
-            Covariance.from_string(entry, version)
+            Covariance._from_string(entry, version)
             for entry in raw_covariances
         ]
         return cls(covariances, version=version)

--- a/oem/components/data.py
+++ b/oem/components/data.py
@@ -57,7 +57,7 @@ class DataSection(object):
         return iter(self.states)
 
     @classmethod
-    def from_string(cls, segment, version):
+    def _from_string(cls, segment, version):
         """Create DataSection from OEM-formatted string.
 
         Args:
@@ -67,7 +67,7 @@ class DataSection(object):
             new_section (DataSection): New DataSection instance.
         """
         raw_states = re.findall(patterns.DATA_LINE, segment, re.MULTILINE)
-        states = [State.from_string(entry, version) for entry in raw_states]
+        states = [State._from_string(entry, version) for entry in raw_states]
         return cls(states, version=version)
 
     @classmethod

--- a/oem/components/header.py
+++ b/oem/components/header.py
@@ -35,7 +35,7 @@ class HeaderSection(KeyValueSection):
         self._parse_fields(fields)
 
     @classmethod
-    def from_string(cls, segment):
+    def _from_string(cls, segment):
         """Create Header Section from OEM-formatted string.
 
         Args:

--- a/oem/components/metadata.py
+++ b/oem/components/metadata.py
@@ -120,7 +120,7 @@ class MetaDataSection(KeyValueSection):
         self._constraint_spec.apply(self)
 
     @classmethod
-    def from_string(cls, segment, version):
+    def _from_string(cls, segment, version):
         """Create MetaDataSection from OEM-formatted string.
 
         Args:

--- a/oem/components/segment.py
+++ b/oem/components/segment.py
@@ -87,7 +87,7 @@ class EphemerisSegment(object):
         return iter(self.states)
 
     @classmethod
-    def from_strings(cls, components, version=CURRENT_VERSION):
+    def _from_strings(cls, components, version=CURRENT_VERSION):
         """Create EphemerisSegment from OEM segment strings.
 
         Args:
@@ -97,12 +97,12 @@ class EphemerisSegment(object):
         Returns:
             new_section (EphemerisSegment): New EphemerisSegment instance.
         """
-        metadata = MetaDataSection.from_string(components[0], version)
-        state_data = DataSection.from_string(components[1], version)
+        metadata = MetaDataSection._from_string(components[0], version)
+        state_data = DataSection._from_string(components[1], version)
         if len(components[2]) == 0:
             covariance_data = None
         else:
-            covariance_data = CovarianceSection.from_string(
+            covariance_data = CovarianceSection._from_string(
                 components[2], version)
         return cls(metadata, state_data, covariance_data, version=version)
 

--- a/oem/components/types.py
+++ b/oem/components/types.py
@@ -70,7 +70,7 @@ class State(object):
         self._constraint_spec.apply(self)
 
     @classmethod
-    def from_string(cls, segment, version):
+    def _from_string(cls, segment, version):
         """Create State from OEM-formatted string.
 
         Args:
@@ -162,7 +162,7 @@ class Covariance(object):
         self.matrix = np.array(matrix)
 
     @classmethod
-    def from_string(cls, segment, version):
+    def _from_string(cls, segment, version):
         """Create Covariance from OEM-formatted string.
 
         Args:

--- a/oem/interface.py
+++ b/oem/interface.py
@@ -119,10 +119,10 @@ class OrbitEphemerisMessage(object):
         contents = re.sub(patterns.COMMENT_LINE, "", contents)
         match = re.match(patterns.CCSDS_EPHEMERIS, contents, re.MULTILINE)
         if match:
-            header = components.HeaderSection.from_string(match.group(1))
+            header = components.HeaderSection._from_string(match.group(1))
             version = header["CCSDS_OEM_VERS"]
             segments = [
-                components.EphemerisSegment.from_strings(raw_segment, version)
+                components.EphemerisSegment._from_strings(raw_segment, version)
                 for raw_segment
                 in re.findall(patterns.DATA_BLOCK, contents, re.MULTILINE)
             ]


### PR DESCRIPTION
The `from_string` component methods are not part of the public API and are now marked as private methods to match the `from_xml` methods.