### PR TITLE
Update documentation and make notation consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ The `OrbitEphemerisMessage` class is the primary interface for OEM Files.
 ```python
 from oem import OrbitEphemerisMessage
 
-ephemeris = OrbitEphemerisMessage.from_ascii_oem(file_path)
+ephemeris = OrbitEphemerisMessage.open("input_file.oem")
 ```
 Each OEM is made up of one or more segments of state and optional covariance data. The `OrbitEphemerisMessage` class provides iterables for both.
 ```python
 for segment in ephemeris:
     for state in segment:
-        print(state.epoch, state.position, state.velocity)
+        print(state.epoch, state.position, state.velocity, state.acceleration)
 
     for covariance in segment.covariances:
         print(covariance.epoch, covariance.matrix)
@@ -39,6 +39,15 @@ for state in ephemeris.states:
     print(state.epoch, state.position, state.velocity)
 for covariance in ephemeris.covariances:
     print(covariance.epoch, covariance.matrix)
+```
+
+The `OrbitEphemerisObject` also facilitates writing of OEMs. To save an already-open OEM, use `.save_as`:
+```python
+ephemeris.save_as("output.oem", file_format="xml")
+```
+To convert an ephemeris from one type to another, use the `.convert` class method.
+```python
+OrbitEphemerisMessage.convert("input_file.oem", "output_file.oem", "kvn")
 ```
 
 

--- a/oem/interface.py
+++ b/oem/interface.py
@@ -91,12 +91,12 @@ class OrbitEphemerisMessage(object):
         The `save_as` method enables saving of copies of an OEM in both KVN and
         XML formats.
 
-        >>> oem.save_as("new.oem", file_format="XML")
+        >>> oem.save_as("new.oem", file_format="xml")
 
         To convert directly between KVN and XML formats, use the `convert`
         class method. For example, to convert a KVN OEM to XML:
 
-        >>> oem.convert("input.oem", "output.oem", "XML")
+        >>> oem.convert("input.oem", "output.oem", "xml")
     """
 
     _constraint_spec = ConstraintSpecification(
@@ -191,22 +191,22 @@ class OrbitEphemerisMessage(object):
             in_file_path (str or Path): Path to original ephemeris.
             out_file_path (str or Path): Desired path for converted ephemeris.
             file_format (str): Desired output format. Options are
-                'KVN' and 'XML'.
+                'kvn' and 'xml'.
         """
         cls.open(in_file_path).save_as(out_file_path, file_format=file_format)
 
-    def save_as(self, file_path, file_format="KVN"):
+    def save_as(self, file_path, file_format="kvn"):
         """Write OEM to file.
 
         Args:
             file_path (str or Path): Desired path for output ephemeris.
             file_format (str, optional): Type of file to output. Options are
-                'KVN' and 'XML'. Default is 'KVN'.
+                'kvn' and 'xml'. Default is 'kvn'.
         """
-        if file_format == "KVN":
+        if file_format == "kvn":
             with open(file_path, "w") as output_file:
                 output_file.write(self._to_ascii_oem())
-        elif file_format == "XML":
+        elif file_format == "xml":
             self._to_xml_oem().write(
                 str(file_path),
                 pretty_print=True,

--- a/oem/interface.py
+++ b/oem/interface.py
@@ -135,7 +135,7 @@ class OrbitEphemerisMessage(object):
         )
 
     @classmethod
-    def from_ascii_oem(cls, file_path):
+    def from_kvn_oem(cls, file_path):
         with open(file_path, "r") as ephem_file:
             contents = ephem_file.read()
         contents = re.sub(patterns.COMMENT_LINE, "", contents)
@@ -175,7 +175,7 @@ class OrbitEphemerisMessage(object):
             oem: OrbitEphemerisMessage instance.
         """
         if is_kvn(file_path):
-            oem = cls.from_ascii_oem(file_path)
+            oem = cls.from_kvn_oem(file_path)
         else:
             oem = cls.from_xml_oem(file_path)
         return oem
@@ -205,7 +205,7 @@ class OrbitEphemerisMessage(object):
         """
         if file_format == "kvn":
             with open(file_path, "w") as output_file:
-                output_file.write(self._to_ascii_oem())
+                output_file.write(self._to_kvn_oem())
         elif file_format == "xml":
             self._to_xml_oem().write(
                 str(file_path),
@@ -216,7 +216,7 @@ class OrbitEphemerisMessage(object):
         else:
             raise ValueError(f"Unrecognized file type: '{file_format}'")
 
-    def _to_ascii_oem(self):
+    def _to_kvn_oem(self):
         lines = self.header._to_string() + "\n"
         lines += "".join(entry._to_string() for entry in self._segments)
         return lines

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -35,7 +35,7 @@ def test_valid_v1_samples(file_path):
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         written_oem_path = Path(tmp_dir) / "written.oem"
-        fmt = "XML" if is_kvn(file_path) else "KVN"
+        fmt = "xml" if is_kvn(file_path) else "kvn"
         OrbitEphemerisMessage.convert(file_path, written_oem_path, fmt)
         written_oem = OrbitEphemerisMessage.open(written_oem_path)
         assert written_oem == oem
@@ -74,7 +74,7 @@ def test_valid_v2_samples(file_path):
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         written_oem_path = Path(tmp_dir) / "written.oem"
-        fmt = "XML" if is_kvn(file_path) else "KVN"
+        fmt = "xml" if is_kvn(file_path) else "kvn"
         OrbitEphemerisMessage.convert(file_path, written_oem_path, fmt)
         written_oem = OrbitEphemerisMessage.open(written_oem_path)
         assert written_oem == oem
@@ -97,7 +97,7 @@ def test_convert():
         OrbitEphemerisMessage.convert(
             test_file,
             converted_xml_path,
-            "KVN"
+            "kvn"
         )
         converted_xml = OrbitEphemerisMessage.open(converted_xml_path)
 
@@ -105,7 +105,7 @@ def test_convert():
         OrbitEphemerisMessage.convert(
             converted_xml_path,
             converted_kvn_path,
-            "XML"
+            "xml"
         )
         converted_kvn = OrbitEphemerisMessage.open(converted_kvn_path)
 


### PR DESCRIPTION
* README now includes notes on `.save_as` and `.convert`.

* KVN/XML notation is consistent across the package.