### PR TITLE
Implement constant-step sampling interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,22 @@ epoch = Time("2020-01-01T00:00:00", scale="utc")
 sampled_state = ephemeris(epoch)
 ```
 
-Note that this type of sampling is only supported if the time system of the target ephemeris is supported by astropy Time objects.
+Note that this type of sampling is only supported if the time system of the target ephemeris is supported by astropy Time objects. The `.steps` method of both `OrbitEphemerisMessage` and `EphemerisSegment` objects enables iterable, equal-time sampling of ephemeris data. The following example samples an OEM at a 60-second interval.
 
-The `OrbitEphemerisObject` facilitates writing of OEMs. To save an already-open OEM, use `.save_as`:
+```python
+for state in oem.steps(60)
+    pass
+```
+
+The above example works for both single- and multi-segment OEMs, however the step sizes may vary at the boundary of the segments. To get consistent step sizes with multiple segments, use the segment interface directly.
+
+```python
+for segment in oem:
+    for state in segment.steps(60):
+        pass
+```
+
+The `OrbitEphemerisMessage` facilitates writing of OEMs. To save an already-open OEM, use `.save_as`:
 ```python
 ephemeris.save_as("output.oem", file_format="xml")
 ```

--- a/oem/components/segment.py
+++ b/oem/components/segment.py
@@ -182,13 +182,23 @@ class EphemerisSegment(object):
         )
 
     def steps(self, step_size):
-        """Sample Segment at equal intervals.
+        """Sample Segment at equal time intervals.
+
+        This method returns a generator producing states at equal time
+        intervals spanning the useable duration of the parent EphemerisSegment.
 
         Args:
             step_size (float): Sample step size in seconds.
 
         Returns:
             steps (generator): Generator of sampled states.
+
+        Examples:
+            Sample states in each segment of an OEM at 60-second intervals:
+
+            >>> for segment in oem:
+            ...    for state in segment.steps(60):
+            ...        pass
         """
         for epoch in time_range(self.useable_start_time,
                                 self.useable_stop_time,

--- a/oem/components/segment.py
+++ b/oem/components/segment.py
@@ -2,7 +2,7 @@ from lxml.etree import SubElement
 
 from oem import CURRENT_VERSION
 from oem.base import ConstraintSpecification, Constraint
-from oem.tools import require
+from oem.tools import require, time_range
 from oem.components.metadata import MetaDataSection
 from oem.components.data import DataSection
 from oem.components.covariance import CovarianceSection
@@ -180,6 +180,20 @@ class EphemerisSegment(object):
             method,
             order
         )
+
+    def steps(self, step_size):
+        """Sample Segment at equal intervals.
+
+        Args:
+            step_size (float): Sample step size in seconds.
+
+        Returns:
+            steps (generator): Generator of sampled states.
+        """
+        for epoch in time_range(self.useable_start_time,
+                                self.useable_stop_time,
+                                step_size):
+            yield self(epoch)
 
     @property
     def states(self):

--- a/oem/interface.py
+++ b/oem/interface.py
@@ -238,13 +238,32 @@ class OrbitEphemerisMessage(object):
         cls.open(in_file_path).save_as(out_file_path, file_format=file_format)
 
     def steps(self, step_size):
-        """Sample Ephemeris at equal intervals.
+        """Sample Ephemeris at equal time intervals.
+
+        This method returns a generator producing states at equal time
+        intervals spanning the useable duration of all segments in the
+        parent OEM.
 
         Args:
             step_size (float): Sample step size in seconds.
 
         Returns:
             steps (generator): Generator of sampled states.
+
+        Examples:
+            Sample states at 60-second intervals:
+
+            >>> for state in oem.steps(60):
+            ...     pass
+
+            Note that spacing between steps will only be constant within
+            segments; when crossing from one segment to another the spacing
+            will vary. To avoid this behavior with multi-segment OEMs, use the
+            segment interface directly:
+
+            >>> for segment in oem:
+            ...    for state in segment.steps(60):
+            ...        pass
         """
         for segment in self:
             for state in segment.steps(step_size):

--- a/oem/interface.py
+++ b/oem/interface.py
@@ -237,6 +237,19 @@ class OrbitEphemerisMessage(object):
         """
         cls.open(in_file_path).save_as(out_file_path, file_format=file_format)
 
+    def steps(self, step_size):
+        """Sample Ephemeris at equal intervals.
+
+        Args:
+            step_size (float): Sample step size in seconds.
+
+        Returns:
+            steps (generator): Generator of sampled states.
+        """
+        for segment in self:
+            for state in segment.steps(step_size):
+                yield state
+
     def save_as(self, file_path, file_format="kvn"):
         """Write OEM to file.
 

--- a/oem/tools.py
+++ b/oem/tools.py
@@ -1,6 +1,7 @@
 import warnings
 import datetime as dt
-from astropy.time import Time
+import numpy as np
+from astropy.time import Time, TimeDelta
 
 
 def parse_str(input_string, metadata):
@@ -158,3 +159,19 @@ def is_kvn(file_path):
         else:
             result = True
     return result
+
+
+def time_range(start_time, stop_time, step_sec):
+    """Sample a range of times.
+
+    Args:
+        start_time (Time): Initial time in sample span.
+        stop_time (Time): Final time in sample span.
+        step_sec (float): Step size in seconds.
+
+    Returns:
+        times (generator): Generator of sample times.
+    """
+    delta = (stop_time - start_time).sec
+    for elapsed in np.arange(0, delta, step_sec):
+        yield start_time + TimeDelta(elapsed, format="sec")

--- a/oem/tools.py
+++ b/oem/tools.py
@@ -162,7 +162,7 @@ def is_kvn(file_path):
 
 
 def time_range(start_time, stop_time, step_sec):
-    """Sample a range of times.
+    """Sample a range of astropy Times.
 
     Args:
         start_time (Time): Initial time in sample span.
@@ -170,7 +170,7 @@ def time_range(start_time, stop_time, step_sec):
         step_sec (float): Step size in seconds.
 
     Returns:
-        times (generator): Generator of sample times.
+        times (generator): Generator of sample astropy Times.
     """
     delta = (stop_time - start_time).sec
     for elapsed in np.arange(0, delta, step_sec):

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -123,3 +123,18 @@ def test_ephemeris_accuracy(coarse_file, fine_file):
                 state.acceleration,
                 6
             )
+
+
+@pytest.mark.parametrize(
+    "input_file", ("GEO_20s.oem", "MEO_20s.oem", "LEO_10s.oem")
+)
+def test_ephemeris_stepping(input_file):
+    sample_file = SAMPLE_DIR / "real" / input_file
+    oem = OrbitEphemerisMessage.open(sample_file)
+
+    for state in oem.steps(601):
+        assert state.epoch in oem
+
+    for segment in oem:
+        for state in oem.steps(601):
+            assert state.epoch in oem

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -136,5 +136,5 @@ def test_ephemeris_stepping(input_file):
         assert state.epoch in oem
 
     for segment in oem:
-        for state in oem.steps(601):
+        for state in segment.steps(601):
             assert state.epoch in oem


### PR DESCRIPTION
Add `.steps` methods for `OrbitEphemerisMessage` and `EphemerisSegment` to enable equal-time sampling of states.