### PR TITLE
Integrate defusedxml for OEM parsing

### DIFF
--- a/oem/interface.py
+++ b/oem/interface.py
@@ -1,6 +1,7 @@
 import re
 
-from lxml.etree import ElementTree, Element, SubElement, parse
+from lxml.etree import ElementTree, Element, SubElement
+from defusedxml.ElementTree import parse
 
 from oem import components, patterns
 from oem.base import Constraint, ConstraintSpecification

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 scipy
 lxml
 astropy
+defusedxml


### PR DESCRIPTION
Address security concerns in XML parsing by switching to `defusedxml`.

Closes #9 