### PR TITLE
Reduce overhead of KVN parsing

### DIFF
--- a/oem/components/segment.py
+++ b/oem/components/segment.py
@@ -111,7 +111,7 @@ class EphemerisSegment(object):
     def _from_strings(cls, components, version):
         metadata = MetaDataSection._from_string(components[0], version)
         state_data = DataSection._from_string(components[1], version, metadata)
-        if len(components[2]) == 0:
+        if components[2] is None:
             covariance_data = None
         else:
             covariance_data = CovarianceSection._from_string(

--- a/oem/tools.py
+++ b/oem/tools.py
@@ -1,4 +1,5 @@
 import warnings
+import re
 import datetime as dt
 import numpy as np
 from astropy.time import Time, TimeDelta
@@ -175,3 +176,30 @@ def time_range(start_time, stop_time, step_sec):
     delta = (stop_time - start_time).sec
     for elapsed in np.arange(0, delta, step_sec):
         yield start_time + TimeDelta(elapsed, format="sec")
+
+
+def regex_block_iter(pattern, contents):
+    """Iterate through blocks of file content.
+
+    Assumes that the input pattern is repeated from the beginning to the end
+    of the file. Raises an exception if every character of the input is not
+    matched as part of a repeated block.
+
+    Args:
+        pattern (str): Regex pattern of repeated block.
+        contents (str): Full contents of file to parse.
+
+    Yields:
+        groups (tuple): Regex match results.
+
+    Raises:
+        ValueError: Failed to parse complete file contents.
+    """
+    idx = 0
+    while idx < len(contents):
+        match = re.match(pattern, contents[idx:], re.MULTILINE)
+        if match:
+            idx += match.span()[1]
+            yield match.groups()
+        else:
+            raise ValueError("Failed to parse complete file contents.")


### PR DESCRIPTION
Addresses inefficiency of the KVN parser on large files. The current method attempts to match the entire file with a single regex, potentially causing memory errors for large files. This update moves to an iterative parsing approach that only attempts to match one block at a time.

Closes #35.