### PR TITLE
Add OEM segment convenience method

### DIFF
--- a/oem/interface.py
+++ b/oem/interface.py
@@ -367,3 +367,7 @@ class OrbitEphemerisMessage(object):
             for segment in self
             for covariance in segment.covariances
         ]
+
+    @property
+    def segments(self):
+        return self._segments


### PR DESCRIPTION
Implements the `OrbitEphemerisMessage.segments` convenience method.

Closes #40.