### PR TITLE
Implement multi-version Python testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,3 @@
-image: python:3.8
-
 stages:
   - build
   - test
@@ -13,13 +11,32 @@ include:
   - template: SAST.gitlab-ci.yml
 
 
-run_tests:
+.run_tests:
   stage: test
   script:
     - python -V
-    - pip install pytest pytest-cov
     - pip install -r requirements.txt
     - pytest -v --junitxml=report.xml --cov=oem --cov-report term tests/
+
+run_tests_py35:
+  extends: .run_tests
+  image: python:3.5
+
+run_tests_py36:
+  extends: .run_tests
+  image: python:3.6
+
+run_tests_py37:
+  extends: .run_tests
+  image: python:3.7
+
+run_tests_py38:
+  extends: .run_tests
+  image: python:3.8
+
+run_tests_py39:
+  extends: .run_tests
+  image: python:3.9
   artifacts:
     paths:
       - .coverage
@@ -27,6 +44,7 @@ run_tests:
       junit: report.xml
 
 enforce_pep8:
+  image: python:3.9
   stage: test
   allow_failure: true
   script:
@@ -36,6 +54,7 @@ enforce_pep8:
 
 
 coverage:
+  image: python:3.9
   stage: document
   rules:
     - if: $CI_COMMIT_BRANCH == "master"
@@ -61,6 +80,7 @@ sast:
 
 
 publish_version:
+  image: python:3.9
   stage: publish
   rules:
     - if: '$CI_COMMIT_TAG != null'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,10 +19,6 @@ include:
     - pip install -r requirements.txt
     - pytest -v --junitxml=report.xml --cov=oem --cov-report term tests/
 
-run_tests_py35:
-  extends: .run_tests
-  image: python:3.5
-
 run_tests_py36:
   extends: .run_tests
   image: python:3.6

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ include:
   stage: test
   script:
     - python -V
+    - pip install pytest pytest-cov
     - pip install -r requirements.txt
     - pytest -v --junitxml=report.xml --cov=oem --cov-report term tests/
 


### PR DESCRIPTION
This change adds testing jobs for versions of Python between 3.6 and 3.9.

Closes #46.