### PR TITLE
Correct compare input ordering

### DIFF
--- a/oem/components/segment.py
+++ b/oem/components/segment.py
@@ -101,7 +101,7 @@ class EphemerisSegment(object):
         )
 
     def __sub__(self, other):
-        return SegmentCompare(self, other)
+        return SegmentCompare(other, self)
 
     def __repr__(self):
         start = str(self.useable_start_time)

--- a/oem/components/types.py
+++ b/oem/components/types.py
@@ -101,7 +101,7 @@ class State(object):
         )
 
     def __sub__(self, other):
-        return StateCompare(self, other)
+        return StateCompare(other, self)
 
     def __repr__(self):
         return f"State({str(self.epoch)})"


### PR DESCRIPTION
Correct compare ordering for `StateCompare` and `SegmentCompare` to align with subtraction ordering.