### PR TITLE
fix: convert to datetime first in format_epoch to retain millisecond precision

### DIFF
--- a/oem/tools.py
+++ b/oem/tools.py
@@ -159,9 +159,14 @@ def format_epoch(epoch):
         epoch (Time, DateTime): Epoch to convert to string.
 
     Returns:
-        formatted_epoch (str): Epoch in YYYY-MM-DDTHH:MM:SS.sss format.
+        formatted_epoch (str): Epoch in YYYY-MM-DDTHH:MM:SS.ssssss format.
     """
-    return epoch.strftime("%Y-%m-%dT%H:%M:%S.%f")
+    if isinstance(epoch, dt.datetime):
+        return epoch.strftime("%Y-%m-%dT%H:%M:%S.%f")
+    elif isinstance(epoch, Time):
+        return epoch.datetime.strftime("%Y-%m-%dT%H:%M:%S.%f")
+    else:
+        raise ValueError(f"Cannot format epoch of type: {type(epoch)}")
 
 
 def require(boolean, message):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,4 +1,7 @@
+from datetime import datetime
+
 import pytest
+from astropy.time import Time
 
 from oem import tools
 
@@ -8,3 +11,9 @@ def test_parse_integer():
     tools.parse_integer(1.0, None)
     with pytest.raises(ValueError):
         tools.parse_integer(1.1, None)
+
+def test_format_epoch():
+    assert tools.format_epoch(datetime.fromisoformat("2024-02-08T19:46:03.597928")) == "2024-02-08T19:46:03.597928"
+    assert tools.format_epoch(Time("2024-02-08T19:46:03.597928")) == "2024-02-08T19:46:03.597928"
+    with pytest.raises(ValueError):
+        tools.format_epoch("2024-02-08T19:46:03.597928Z")


### PR DESCRIPTION
There is another fix for this I believe. `astropy.Time` takes an optional `precision` field. From the docs:

```
precision : int, optional
    Digits of precision in string representation of time
```

For example:
```
test_string = "2024-02-08T19:46:03.597928"
assert Time(test_string, precision=6).strftime("%Y-%m-%dT%H:%M:%S.%f") == test_string #true
assert Time(test_string).strftime("%Y-%m-%dT%H:%M:%S.%f") == test_string #false
```

Could also add a precision arg to everywhere `Time` is used, but that might be harder to keep track of in the library. Let me know your preference.